### PR TITLE
Fixed Certificate Generation

### DIFF
--- a/lib/pki/toolbox.js
+++ b/lib/pki/toolbox.js
@@ -387,7 +387,7 @@ function x509Date(date) {
         return ("00000" + s).substr(-l, l);
     }
 
-    return w(Y, 4) + w(M, 2) + w(D, 2) + w(h, 2) + w(m, 2) + w(s, 2) + "Z";
+    return w(Y, 2) + w(M, 2) + w(D, 2) + w(h, 2) + w(m, 2) + w(s, 2) + "Z";
 }
 toolbox.x509Date = x509Date;
 


### PR DESCRIPTION
The instructions for running node-opcua's test read as follows:

```
$ git clone git://github.com/node-opcua/node-opcua.git
$ cd node-opcua
$ npm install
$ npm test
```

However, Doing that (on a mac) will result in the following error:

```
          set OPENSSL_CONF=/Users/brett/Projects/node-opcua/node_modules/node-opcua-pki/lib/pki/empty_config.cnf
                  OPENSSL_CONF /Users/brett/Projects/node-opcua/node_modules/node-opcua-pki/lib/pki/empty_config.cnf
                  RANDFILE     /Users/brett/Projects/node-opcua/certificates/PKI/own/private/random.rnd
                  CMD         openssl  ca  -config conf/caconfig.cnf  -startdate 20160718212047Z -enddate 20170718212047Z -batch -out "/Users/brett/Projects/node-opcua/certificates/client_cert_1024.pem" -in "/Users/brett/Projects/node-opcua/certificates/client_cert_1024.pem.csr"
                  CWD          /Users/brett/Projects/node-opcua/certificates/CA
        stderr Using configuration from conf/caconfig.cnf
        stderr start date is invalid, it should be YYMMDDHHMMSSZ
        stderr 45289:error:0E06D06C:configuration file routines:NCONF_get_string:no value:/BuildRoot/Library/Caches/com.apple.xbs/Sources/OpenSSL098/OpenSSL098-59.40.2/src/crypto/conf/conf_lib.c:329:group=CA_default name=email_in_dn
 ########################################### OPENSSL ERROR  ###############################
Command failed: "openssl" ca  -config conf/caconfig.cnf  -startdate 20160718212047Z -enddate 20170718212047Z -batch -out "/Users/brett/Projects/node-opcua/certificates/client_cert_1024.pem" -in "/Users/brett/Projects/node-opcua/certificates/client_cert_1024.pem.csr"
Using configuration from conf/caconfig.cnf
start date is invalid, it should be YYMMDDHHMMSSZ
45289:error:0E06D06C:configuration file routines:NCONF_get_string:no value:/BuildRoot/Library/Caches/com.apple.xbs/Sources/OpenSSL098/OpenSSL098-59.40.2/src/crypto/conf/conf_lib.c:329:group=CA_default name=email_in_dn

 ########################################### OPENSSL ERROR  ###############################
ERROR  Command failed: "openssl" ca  -config conf/caconfig.cnf  -startdate 20160718212047Z -enddate 20170718212047Z -batch -out "/Users/brett/Projects/node-opcua/certificates/client_cert_1024.pem" -in "/Users/brett/Projects/node-opcua/certificates/client_cert_1024.pem.csr"
Using configuration from conf/caconfig.cnf
start date is invalid, it should be YYMMDDHHMMSSZ
45289:error:0E06D06C:configuration file routines:NCONF_get_string:no value:/BuildRoot/Library/Caches/com.apple.xbs/Sources/OpenSSL098/OpenSSL098-59.40.2/src/crypto/conf/conf_lib.c:329:group=CA_default name=email_in_dn

Command failed: "openssl" ca  -config conf/caconfig.cnf  -startdate 20160718212047Z -enddate 20170718212047Z -batch -out "/Users/brett/Projects/node-opcua/certificates/client_cert_1024.pem" -in "/Users/brett/Projects/node-opcua/certificates/client_cert_1024.pem.csr"
Using configuration from conf/caconfig.cnf
start date is invalid, it should be YYMMDDHHMMSSZ
45289:error:0E06D06C:configuration file routines:NCONF_get_string:no value:/BuildRoot/Library/Caches/com.apple.xbs/Sources/OpenSSL098/OpenSSL098-59.40.2/src/crypto/conf/conf_lib.c:329:group=CA_default name=email_in_dn
```

This PR formats the date as `YYMMDDHHMMSSZ` instead of  `YYYYMMDDHHMMSSZ`
