### PR TITLE
TypeError: Path must be a string. Received undefined

### DIFF
--- a/lib/misc/install_prerequisite.js
+++ b/lib/misc/install_prerequisite.js
@@ -117,19 +117,13 @@ function install_and_check_win32_openssl_version(callback) {
     var download_folder = path.join(os.tmpdir(), ".");
 
     function get_openssl_folder_win32() {
-
-        var openssl_folder;
         if (process.env.LOCALAPPDATA) {
             var user_program_folder = path.join(process.env.LOCALAPPDATA, "Programs");
             if (fs.existsSync(user_program_folder)) {
-                openssl_folder = path.join(user_program_folder, "openssl");
-                return openssl_folder;
+                return path.join(user_program_folder, "openssl");
             }
-        } else {
-            openssl_folder = path.join(process.cwd(), "openssl");
         }
-        return openssl_folder;
-
+        return path.join(process.cwd(), "openssl");
     }
 
     function get_openssl_exec_path_win32() {


### PR DESCRIPTION
The function `get_openssl_folder_win32` now returns local ssl path if `LOCALAPPDATA` environment variable is set AND the `Programs` directory does not exist. issue #2 