### PR TITLE
OpenSSL random file does not exist

### DIFF
--- a/lib/pki/certificate_authority.ts
+++ b/lib/pki/certificate_authority.ts
@@ -47,7 +47,8 @@ import {
     quote,
     setEnv,
     useRandFile,
-    x509Date
+    x509Date,
+    createRandomFileIfNotExist
 } from "./toolbox";
 
 const config = {
@@ -147,7 +148,13 @@ function construct_CertificateAuthority(cauthority: CertificateAuthority, callba
 
     const keySize = cauthority.keySize;
 
+    const randomFile = "random.rnd";
+
     const tasks = [
+        (callback: ErrorCallback) => displayTitle("Creating random file random.rnd", callback),
+
+        (callback: ErrorCallback) =>
+            createRandomFileIfNotExist(randomFile, options, callback),
 
         (callback: ErrorCallback) => displayTitle("Generate the CA private Key - " + keySize, callback),
 
@@ -156,7 +163,7 @@ function construct_CertificateAuthority(cauthority: CertificateAuthority, callba
         // Triple-DES and stored in a PEM format so that it is readable as ASCII text.
         (callback: ErrorCallback) => execute_openssl("genrsa " +
             " -out  private/cakey.pem" +
-            (useRandFile() ? " -rand random.rnd" : "") +
+            (useRandFile() ? " -rand " + randomFile : "") +
             " " + keySize, options, callback),
 
         (callback: ErrorCallback) => displayTitle("Generate a certificate request for the CA key", callback),

--- a/lib/pki/certificate_manager.ts
+++ b/lib/pki/certificate_manager.ts
@@ -284,7 +284,7 @@ export class CertificateManager {
                 if (!exists) {
                     debugLog("generating private key ...");
                     setEnv("RANDFILE", this.randomFile);
-                    createPrivateKey(this.privateKey, this.keySize, (err?: Error) => {
+                    createPrivateKey(this.privateKey, this.keySize, (err?: Error | null | undefined) => {
                         return callback(err);
                     });
                 } else {

--- a/test/test_crypto_create_CA.ts
+++ b/test/test_crypto_create_CA.ts
@@ -75,10 +75,10 @@ describe("testing test_crypto_create_CA", function () {
         const cwd = path.join(__dirname, "../tmp");
 
         fs.existsSync(
-            path.join(__dirname, "../tmp/certificates/discoveryServer_cert_2048.pem"))
+            path.join(cwd, "certificates/discoveryServer_cert_2048.pem"))
             .should.eql(false);
 
-        console.log(" folder = ", path.join(__dirname, "../tmp/certificates/discoveryServer_cert_2048.pem"));
+        console.log(" folder = ", path.join(cwd, "certificates/discoveryServer_cert_2048.pem"));
 
         const date1 = new Date();
 
@@ -86,7 +86,7 @@ describe("testing test_crypto_create_CA", function () {
 
             if (err) { return done(err); }
             fs.existsSync(
-                path.join(__dirname, "../tmp/certificates/discoveryServer_cert_2048.pem"))
+                path.join(cwd, "certificates/discoveryServer_cert_2048.pem"))
                 .should.eql(true);
 
             // running a second time should be faster


### PR DESCRIPTION
Newer versions of OpenSSL does not create random files if they don't exist.

This fix runs `openssl rand -out <randFile> -hex 256` to make sure the random file
is created before it is being used.

potentially fixes #7.

I really need some help to improve/test the code, I'm not that familiar with how `openssl` uses the random file or how long it should be.

I'm not using `-writerand` because the older versions doesn't seem to support it.