### PR TITLE
fixed slashes in Subject CN

### DIFF
--- a/lib/misc/subject.ts
+++ b/lib/misc/subject.ts
@@ -66,7 +66,7 @@ export class Subject implements SubjectOptions {
 
     public static parse(str: string): SubjectOptions {
 
-        const elements = str.split("/");
+        const elements = str.split(/\/(?=[^\/]*?=)/);
         const options: any = {};
 
         elements.forEach((element: string) => {

--- a/test/test_subject.ts
+++ b/test/test_subject.ts
@@ -29,4 +29,12 @@ describe("Subject", () => {
         subject.commonName!.should.eql("Hello");
         subject.domainComponent!.should.eql("MYDOMAIN");
     });
+    it("should parse a long CN with slashes SubjectLine ", () => {
+
+        const str = "/CN=PC.DOMAIN.COM/path/scada/server@PC/DC=/O=Sterfive/L=Orleans/C=FR";
+
+        const subject = Subject.parse(str);
+        subject.commonName!.should.eql("PC.DOMAIN.COM/path/scada/server@PC");
+        subject.domainComponent!.should.eql("");
+    });
 });


### PR DESCRIPTION
When I try to run a server on my windows machine (in a windows domain) for the first time a Subject is created that has slashes in the name similar to the one in the test.

This fix enhances the parsing of the subject name to search for / only when it is followed by a some characters and an =