### PR TITLE
fix the problem of createPKI never end

### DIFF
--- a/lib/misc/install_prerequisite.ts
+++ b/lib/misc/install_prerequisite.ts
@@ -293,6 +293,9 @@ function install_and_check_win32_openssl_version(callback: (err: Error | null, o
         const download = wget.download(url, outputFilename, options);
         download.on("error", (err: Error) => {
             console.log(err);
+            setImmediate(() => {
+                callback(err);
+            });
         });
         download.on("end", (output: string) => {
             // istanbul ignore next


### PR DESCRIPTION
## Description

Fixing the problem that the createPKI command never end in the case of running on Windows when the system has no Internet connection.
`node ./bin/crypto_create_CA.js createPKI`


The problem also affect 'node-opuca'
ex.
calling `await OPCUAClient.create({...}).connect('opc.tcp://....')` never return.


## how to reproducing the problem
 
1. Use windows.
2. remove following cache files.
   * remove `C:\Users\xxxx\AppData\local\Temp\openssl-1.0.2u-x64_86-win64.zip`
   * remove `C:\Users\yogi\AppData\Local\Programs\openssl`
3. clone this repository in the Window platform. 
4. `npm install` and `npm run build`
5. unplug ethernet or wifi.
6. `node .\bin\crypto_create_CA.js createPKI`
 then the command never end.